### PR TITLE
README: Add specification for api-endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Offical server at <http://ddb.glidernet.org>.
 
 ## API-Endpoints
 ### /download
-
 This returns a CSVish-File. Each value is quoted with `'`,
 Each line starting with `#` is a comment.
 
@@ -26,6 +25,9 @@ Example:
 'F','0123BC','LS-4','X-0123','23','Y','Y'
 'F','DEADBE','DR-400','X-EABC','','N','N'
 ```
+
+### /download/download-fln.php
+This returns the device database in a flarmnet-compatible format.
 
 ## ToDo
 - finish multi languages management

--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
 # ogn-ddb
 OGN Devices DataBAse
 
-To Do: finish multi languages management
+Offical server at <http://ddb.glidernet.org>.
+
+## API-Endpoints
+### /download
+
+This returns a CSVish-File. Each value is quoted with `'`,
+Each line starting with `#` is a comment.
+
+Field           | Possible Values
+--------------- | -------------------------------
+device\_type    | `^[A-F0-9]{6}$`
+device\_id      | any string
+aircraft\_model | `^[FIO]$`
+registration    | any string
+cn              | any string
+tracked         | `^[YN]$`
+identified      | `^[YN]$`
+
+
+Example:
+```
+#DEVICE_TYPE,DEVICE_ID,AIRCRAFT_MODEL,REGISTRATION,CN,TRACKED,IDENTIFIED
+'F','0123BC','LS-4','X-0123','23','Y','Y'
+'F','DEADBE','DR-400','X-EABC','','N','N'
+```
+
+## ToDo
+- finish multi languages management
+- document accurate meaning of `tracked` and `identified`


### PR DESCRIPTION
Speaking of a "good api" in #2, it should be a good idea to add some specification for the delivered file (though it is trivial).

If desired, we could add something like this:

```
### Existing (public) implementations using ddb:
- C++: https://github.com/gewesp/cpp-lib/blob/master/src/ogn.cpp
- Python: https://github.com/kerel-fs/ogn-privacy-stats/blob/master/ognutils.py
```
