### PR TITLE
Add robots.txt to disallow ./downloads/

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /download/


### PR DESCRIPTION
Disallow the scanning of ./downloads/ to prevent indexing
of the database by web crawlers (e.g. google).
